### PR TITLE
Feature/#27 레시피 재료 추가 API 

### DIFF
--- a/src/main/java/com/hackathonteam1/refreshrator/controller/RecipeController.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/controller/RecipeController.java
@@ -2,10 +2,10 @@ package com.hackathonteam1.refreshrator.controller;
 
 import com.hackathonteam1.refreshrator.annotation.AuthenticatedUser;
 import com.hackathonteam1.refreshrator.dto.ResponseDto;
-import com.hackathonteam1.refreshrator.dto.request.recipe.ModifyRecipeDto;
+import com.hackathonteam1.refreshrator.dto.request.recipe.IngredientRecipeDto;
+import com.hackathonteam1.refreshrator.dto.request.recipe.RecipeDto;
 import com.hackathonteam1.refreshrator.dto.request.recipe.RegisterRecipeDto;
 import com.hackathonteam1.refreshrator.dto.response.recipe.DetailRecipeDto;
-import com.hackathonteam1.refreshrator.entity.Recipe;
 import com.hackathonteam1.refreshrator.entity.User;
 import com.hackathonteam1.refreshrator.service.RecipeService;
 import jakarta.validation.Valid;
@@ -37,15 +37,15 @@ public class RecipeController {
 
     @PatchMapping("/{recipe_id}")
     public ResponseEntity<ResponseDto<Void>> modify(
-            @RequestBody @Valid ModifyRecipeDto modifyRecipeDto, @AuthenticatedUser User user, @PathVariable("recipe_id") UUID recipeId){
-        recipeService.modifyContent(modifyRecipeDto, user, recipeId);
+            @RequestBody @Valid RecipeDto recipeDto, @AuthenticatedUser User user, @PathVariable("recipe_id") UUID recipeId){
+        recipeService.modifyContent(recipeDto, user, recipeId);
         return new ResponseEntity<>(ResponseDto.res(HttpStatus.OK,"레시피 수정 성공"),HttpStatus.OK);
     }
 
-    @PostMapping("/{recipe_id}/ingredients/{ingredient_id}")
+    @PostMapping("/{recipe_id}/ingredients")
     public ResponseEntity<ResponseDto<Void>> registerIngredientRecipe(@PathVariable("recipe_id") UUID recipeId,
-                                                                      @PathVariable("ingredient_id") UUID ingredientId, @AuthenticatedUser User user){
-        recipeService.registerIngredientRecipe(user, recipeId, ingredientId);
+                                                                      @RequestBody @Valid IngredientRecipeDto ingredientRecipeDto, @AuthenticatedUser User user){
+        recipeService.registerIngredientRecipe(user, recipeId, ingredientRecipeDto);
         return new ResponseEntity<>(ResponseDto.res(HttpStatus.CREATED, "레시피 재료 등록 성공"),HttpStatus.CREATED);
     }
 

--- a/src/main/java/com/hackathonteam1/refreshrator/controller/RecipeController.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/controller/RecipeController.java
@@ -5,6 +5,7 @@ import com.hackathonteam1.refreshrator.dto.ResponseDto;
 import com.hackathonteam1.refreshrator.dto.request.recipe.ModifyRecipeDto;
 import com.hackathonteam1.refreshrator.dto.request.recipe.RegisterRecipeDto;
 import com.hackathonteam1.refreshrator.dto.response.recipe.DetailRecipeDto;
+import com.hackathonteam1.refreshrator.entity.Recipe;
 import com.hackathonteam1.refreshrator.entity.User;
 import com.hackathonteam1.refreshrator.service.RecipeService;
 import jakarta.validation.Valid;
@@ -39,6 +40,13 @@ public class RecipeController {
             @RequestBody @Valid ModifyRecipeDto modifyRecipeDto, @AuthenticatedUser User user, @PathVariable("recipe_id") UUID recipeId){
         recipeService.modifyContent(modifyRecipeDto, user, recipeId);
         return new ResponseEntity<>(ResponseDto.res(HttpStatus.OK,"레시피 수정 성공"),HttpStatus.OK);
+    }
+
+    @PostMapping("/{recipe_id}/ingredients/{ingredient_id}")
+    public ResponseEntity<ResponseDto<Void>> registerIngredientRecipe(@PathVariable("recipe_id") UUID recipeId,
+                                                                      @PathVariable("ingredient_id") UUID ingredientId, @AuthenticatedUser User user){
+        recipeService.registerIngredientRecipe(user, recipeId, ingredientId);
+        return new ResponseEntity<>(ResponseDto.res(HttpStatus.CREATED, "레시피 재료 등록 성공"),HttpStatus.CREATED);
     }
 
 

--- a/src/main/java/com/hackathonteam1/refreshrator/dto/request/recipe/IngredientRecipeDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/request/recipe/IngredientRecipeDto.java
@@ -1,0 +1,24 @@
+package com.hackathonteam1.refreshrator.dto.request.recipe;
+
+import com.hackathonteam1.refreshrator.exception.BadRequestException;
+import com.hackathonteam1.refreshrator.exception.errorcode.ErrorCode;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Getter
+public class IngredientRecipeDto {
+    @NotNull
+    private List<UUID> ingredientIds;
+
+    public List<UUID> nonDupIngredientIds(){
+        List<UUID> nonDupIngredientIds = this.getIngredientIds().stream().distinct().collect(Collectors.toList());
+        if(this.ingredientIds.size() != nonDupIngredientIds.size()){
+            throw new BadRequestException(ErrorCode.DUPLICATED_RECIPE_INGREDIENT);
+        }
+        return nonDupIngredientIds;
+    }
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/dto/request/recipe/RecipeDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/request/recipe/RecipeDto.java
@@ -1,7 +1,5 @@
 package com.hackathonteam1.refreshrator.dto.request.recipe;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class ModifyRecipeDto {
+public class RecipeDto {
 
     @Size(min = 1, max = 20)
     private String name;

--- a/src/main/java/com/hackathonteam1/refreshrator/exception/BadRequestException.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/exception/BadRequestException.java
@@ -1,0 +1,13 @@
+package com.hackathonteam1.refreshrator.exception;
+
+import com.hackathonteam1.refreshrator.exception.errorcode.ErrorCode;
+
+public class BadRequestException extends CustomException{
+    public BadRequestException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public BadRequestException(ErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/exception/errorcode/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     LENGTH("4003", "길이가 유효하지 않습니다."),
     EMAIL("4004", "이메일 형식이 유효하지 않습니다."),
     NOT_NULL("4005", "필수값이 공백입니다."),
+    DUPLICATED_RECIPE_INGREDIENT("4006","레시피에 중복되는 재료 추가할 수 없습니다."),
 
     //AuthorizedException
     COOKIE_NOT_FOUND("4010", "쿠키를 찾을 수 없습니다."),

--- a/src/main/java/com/hackathonteam1/refreshrator/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/exception/errorcode/ErrorCode.java
@@ -1,5 +1,6 @@
 package com.hackathonteam1.refreshrator.exception.errorcode;
 
+import com.hackathonteam1.refreshrator.entity.Recipe;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -31,7 +32,8 @@ public enum ErrorCode {
     FRIDGE_NOT_FOUND("4044","냉장고를 찾을 수 없습니다"),
 
     //ConflictException
-    DUPLICATED_EMAIL("4090", "이미 사용 중인 이메일입니다.");
+    DUPLICATED_EMAIL("4090", "이미 사용 중인 이메일입니다."),
+    RECIPE_INGREDIENT_CONFLICT("4091", "이미 해당 레시피에 존재하는 재료입니다.");
 
 
     private final String code;

--- a/src/main/java/com/hackathonteam1/refreshrator/service/RecipeService.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/service/RecipeService.java
@@ -18,4 +18,6 @@ public interface RecipeService {
 
     public void modifyContent(ModifyRecipeDto modifyRecipeDto, User user, UUID recipeId);
 
+    public void registerIngredientRecipe(User user, UUID recipeId, UUID ingredientId);
+
 }

--- a/src/main/java/com/hackathonteam1/refreshrator/service/RecipeService.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/service/RecipeService.java
@@ -1,10 +1,10 @@
 package com.hackathonteam1.refreshrator.service;
 
-import com.hackathonteam1.refreshrator.dto.request.recipe.ModifyRecipeDto;
+import com.hackathonteam1.refreshrator.dto.request.recipe.IngredientRecipeDto;
+import com.hackathonteam1.refreshrator.dto.request.recipe.RecipeDto;
 import com.hackathonteam1.refreshrator.dto.request.recipe.RegisterRecipeDto;
 import com.hackathonteam1.refreshrator.dto.response.recipe.DetailRecipeDto;
 import com.hackathonteam1.refreshrator.entity.User;
-import org.springframework.stereotype.Service;
 
 import java.util.UUID;
 
@@ -16,8 +16,8 @@ public interface RecipeService {
     //레시피 상세조회
     public DetailRecipeDto getDetail(UUID recipeId);
 
-    public void modifyContent(ModifyRecipeDto modifyRecipeDto, User user, UUID recipeId);
+    public void modifyContent(RecipeDto recipeDto, User user, UUID recipeId);
 
-    public void registerIngredientRecipe(User user, UUID recipeId, UUID ingredientId);
+    public void registerIngredientRecipe(User user, UUID recipeId, IngredientRecipeDto ingredientRecipeDto);
 
 }

--- a/src/main/java/com/hackathonteam1/refreshrator/service/RecipeServiceImpl.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/service/RecipeServiceImpl.java
@@ -7,6 +7,7 @@ import com.hackathonteam1.refreshrator.entity.Ingredient;
 import com.hackathonteam1.refreshrator.entity.IngredientRecipe;
 import com.hackathonteam1.refreshrator.entity.Recipe;
 import com.hackathonteam1.refreshrator.entity.User;
+import com.hackathonteam1.refreshrator.exception.ConflictException;
 import com.hackathonteam1.refreshrator.exception.ForbiddenException;
 import com.hackathonteam1.refreshrator.exception.NotFoundException;
 import com.hackathonteam1.refreshrator.exception.errorcode.ErrorCode;
@@ -49,7 +50,7 @@ public class RecipeServiceImpl implements RecipeService{
         Recipe recipe = findRecipeByRecipeId(recipeId);
         List<IngredientRecipe> ingredientRecipes = findAllIngredientRecipeByRecipe(recipe);
 
-        List<Ingredient> ingredients = ingredientRecipes.stream().map(i->i.getIngredient()).collect(Collectors.toList());
+        List<Ingredient> ingredients = findAllIngredientByIngredientRecipes(ingredientRecipes);
 
         DetailRecipeDto detailRecipeDto = DetailRecipeDto.detailRecipeDto(recipe.getName(),ingredients, recipe.getCookingStep());
 
@@ -72,6 +73,23 @@ public class RecipeServiceImpl implements RecipeService{
         recipeRepository.save(recipe);
     }
 
+    //레시피 재료 등록
+    @Override
+    public void registerIngredientRecipe(User user, UUID recipeId, UUID ingredientId) {
+        Recipe recipe = findRecipeByRecipeId(recipeId);
+        checkAuth(recipe.getUser(), user);
+
+        List<Ingredient> ingredients = findAllIngredientByIngredientRecipes(findAllIngredientRecipeByRecipe(recipe));
+
+        Ingredient newIngredient = findIngredientByIngredientId(ingredientId);
+
+        if(ingredients.stream().anyMatch(i->i.getId().equals(newIngredient.getId()))){
+            throw new ConflictException(ErrorCode.RECIPE_INGREDIENT_CONFLICT);
+        }
+
+        registerRecipeIngredient(newIngredient, recipe);
+    }
+
     private Ingredient findIngredientByIngredientId(UUID ingredientId){
         return ingredientRepository.findById(ingredientId).orElseThrow(()-> new NotFoundException(ErrorCode.INGREDIENT_NOT_FOUND));
     }
@@ -89,6 +107,12 @@ public class RecipeServiceImpl implements RecipeService{
         return recipeRepository.findById(recipeId).orElseThrow(()-> new NotFoundException(ErrorCode.RECIPE_NOT_FOUND));
     }
 
+    //IngredientRecipe 리스트로 Ingredient 리스트 생성하는 메서드
+    private List<Ingredient> findAllIngredientByIngredientRecipes(List<IngredientRecipe> ingredientRecipes){
+        return ingredientRecipes.stream().map(i->i.getIngredient()).collect(Collectors.toList());
+    }
+
+    //Recipe로 해당 Recipe 내에 존재하는 IngredientRecipe 리스트를 반환하는 메서드
     private List<IngredientRecipe> findAllIngredientRecipeByRecipe(Recipe recipe){
         return ingredientRecipeRepository.findAllByRecipe(recipe).orElseThrow(()-> new NotFoundException(ErrorCode.INGREDIENT_RECIPE_NOT_FOUND));
     }


### PR DESCRIPTION
## Description
레시피 재료 추가 API 

## Changes
- [x] RecipeController
- [x] RecipeService
- [x] RecipeServiceImpl
- [x] ErrorCode
- [x] IngredientRecipeDto 

## Additional context
레시피명, 조리법 수정 API와 나누어서 레시피 재료들을 추가하는 API 작성.
레시피에 이미 존재하는 재료를 추가할 경우 예외처리, 중복되는 재료 추가 요청 시 예외처리.

### URL
url은 /recipes/{recipe_id}/ingredients를 사용함.

Closes #27 