### PR TITLE
Feature/#28 레시피 재료 삭제 API 

### DIFF
--- a/src/main/java/com/hackathonteam1/refreshrator/controller/RecipeController.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/controller/RecipeController.java
@@ -2,8 +2,9 @@ package com.hackathonteam1.refreshrator.controller;
 
 import com.hackathonteam1.refreshrator.annotation.AuthenticatedUser;
 import com.hackathonteam1.refreshrator.dto.ResponseDto;
-import com.hackathonteam1.refreshrator.dto.request.recipe.IngredientRecipeDto;
-import com.hackathonteam1.refreshrator.dto.request.recipe.RecipeDto;
+import com.hackathonteam1.refreshrator.dto.request.recipe.DeleteIngredientRecipesDto;
+import com.hackathonteam1.refreshrator.dto.request.recipe.RegisterIngredientRecipesDto;
+import com.hackathonteam1.refreshrator.dto.request.recipe.ModifyRecipeDto;
 import com.hackathonteam1.refreshrator.dto.request.recipe.RegisterRecipeDto;
 import com.hackathonteam1.refreshrator.dto.response.recipe.DetailRecipeDto;
 import com.hackathonteam1.refreshrator.entity.User;
@@ -37,16 +38,23 @@ public class RecipeController {
 
     @PatchMapping("/{recipe_id}")
     public ResponseEntity<ResponseDto<Void>> modify(
-            @RequestBody @Valid RecipeDto recipeDto, @AuthenticatedUser User user, @PathVariable("recipe_id") UUID recipeId){
-        recipeService.modifyContent(recipeDto, user, recipeId);
+            @RequestBody @Valid ModifyRecipeDto modifyRecipeDto, @AuthenticatedUser User user, @PathVariable("recipe_id") UUID recipeId){
+        recipeService.modifyContent(modifyRecipeDto, user, recipeId);
         return new ResponseEntity<>(ResponseDto.res(HttpStatus.OK,"레시피 수정 성공"),HttpStatus.OK);
     }
 
     @PostMapping("/{recipe_id}/ingredients")
     public ResponseEntity<ResponseDto<Void>> registerIngredientRecipe(@PathVariable("recipe_id") UUID recipeId,
-                                                                      @RequestBody @Valid IngredientRecipeDto ingredientRecipeDto, @AuthenticatedUser User user){
-        recipeService.registerIngredientRecipe(user, recipeId, ingredientRecipeDto);
+                                                                      @RequestBody @Valid RegisterIngredientRecipesDto registerIngredientRecipesDto, @AuthenticatedUser User user){
+        recipeService.registerIngredientRecipe(user, recipeId, registerIngredientRecipesDto);
         return new ResponseEntity<>(ResponseDto.res(HttpStatus.CREATED, "레시피 재료 등록 성공"),HttpStatus.CREATED);
+    }
+
+    @DeleteMapping("/{recipe_id}/ingredients")
+    public ResponseEntity<ResponseDto<Void>> deleteIngredientRecipe(@PathVariable("recipe_id") UUID recipeId,
+                                                                    @RequestBody @Valid DeleteIngredientRecipesDto deleteIngredientRecipesDto, @AuthenticatedUser User user){
+        recipeService.deleteIngredientRecipe(user, recipeId, deleteIngredientRecipesDto);
+        return new ResponseEntity<>(ResponseDto.res(HttpStatus.OK, "레시피 재료 삭제 성공"),HttpStatus.OK);
     }
 
 

--- a/src/main/java/com/hackathonteam1/refreshrator/dto/request/recipe/DeleteIngredientRecipesDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/request/recipe/DeleteIngredientRecipesDto.java
@@ -1,0 +1,26 @@
+package com.hackathonteam1.refreshrator.dto.request.recipe;
+
+import com.hackathonteam1.refreshrator.exception.BadRequestException;
+import com.hackathonteam1.refreshrator.exception.errorcode.ErrorCode;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Getter
+public class DeleteIngredientRecipesDto {
+
+    @NotNull
+    private List<UUID> ingredientRecipeIds;
+
+    public List<UUID> nonDupIngredientIds(){
+        List<UUID> nonDupIngredientIds = this.getIngredientRecipeIds().stream().distinct().collect(Collectors.toList());
+        if(this.getIngredientRecipeIds().size() != nonDupIngredientIds.size()){
+            throw new BadRequestException(ErrorCode.DUPLICATED_RECIPE_INGREDIENT);
+        }
+        return nonDupIngredientIds;
+    }
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/dto/request/recipe/ModifyRecipeDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/request/recipe/ModifyRecipeDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class RecipeDto {
+public class ModifyRecipeDto {
 
     @Size(min = 1, max = 20)
     private String name;

--- a/src/main/java/com/hackathonteam1/refreshrator/dto/request/recipe/RegisterIngredientRecipesDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/request/recipe/RegisterIngredientRecipesDto.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Getter
-public class IngredientRecipeDto {
+public class RegisterIngredientRecipesDto {
     @NotNull
     private List<UUID> ingredientIds;
 

--- a/src/main/java/com/hackathonteam1/refreshrator/dto/request/recipe/RegisterRecipeDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/request/recipe/RegisterRecipeDto.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.UUID;
 
 @Getter
-@AllArgsConstructor
 public class RegisterRecipeDto {
 
     @Size(min = 1, max = 20)

--- a/src/main/java/com/hackathonteam1/refreshrator/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/exception/errorcode/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
     LENGTH("4003", "길이가 유효하지 않습니다."),
     EMAIL("4004", "이메일 형식이 유효하지 않습니다."),
     NOT_NULL("4005", "필수값이 공백입니다."),
-    DUPLICATED_RECIPE_INGREDIENT("4006","레시피에 중복되는 재료 추가할 수 없습니다."),
+    DUPLICATED_RECIPE_INGREDIENT("4006","중복되는 레시피 재료 관련 요청은 불가합니다."),
 
     //AuthorizedException
     COOKIE_NOT_FOUND("4010", "쿠키를 찾을 수 없습니다."),

--- a/src/main/java/com/hackathonteam1/refreshrator/service/RecipeService.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/service/RecipeService.java
@@ -1,7 +1,8 @@
 package com.hackathonteam1.refreshrator.service;
 
-import com.hackathonteam1.refreshrator.dto.request.recipe.IngredientRecipeDto;
-import com.hackathonteam1.refreshrator.dto.request.recipe.RecipeDto;
+import com.hackathonteam1.refreshrator.dto.request.recipe.DeleteIngredientRecipesDto;
+import com.hackathonteam1.refreshrator.dto.request.recipe.RegisterIngredientRecipesDto;
+import com.hackathonteam1.refreshrator.dto.request.recipe.ModifyRecipeDto;
 import com.hackathonteam1.refreshrator.dto.request.recipe.RegisterRecipeDto;
 import com.hackathonteam1.refreshrator.dto.response.recipe.DetailRecipeDto;
 import com.hackathonteam1.refreshrator.entity.User;
@@ -16,8 +17,13 @@ public interface RecipeService {
     //레시피 상세조회
     public DetailRecipeDto getDetail(UUID recipeId);
 
-    public void modifyContent(RecipeDto recipeDto, User user, UUID recipeId);
+    //레시피 내용 수정
+    public void modifyContent(ModifyRecipeDto modifyRecipeDto, User user, UUID recipeId);
 
-    public void registerIngredientRecipe(User user, UUID recipeId, IngredientRecipeDto ingredientRecipeDto);
+    //레시피 재료 추가
+    public void registerIngredientRecipe(User user, UUID recipeId, RegisterIngredientRecipesDto registerIngredientRecipesDto);
+
+    //레시피 재료 삭제
+    public void deleteIngredientRecipe(User user, UUID recipeId, DeleteIngredientRecipesDto deleteIngredientRecipesDto);
 
 }


### PR DESCRIPTION
## Description
레시피 재료 삭제 API

## Changes
- [x] RecipeController
- [x] RecipeService
- [x] RecipeServiceImpl
- [x] ErrorCode
- [x] IngredientRecipeResponseDto

### 수정된 dto 
- [x] DeleteIngredientRecipeDto
- [x] ModifyRecipeDto
- [x] registerIngredientRecipesDto

## Additional context
레시피명, 조리법 수정 API와 나누어서 레시피 재료를 단일 삭제하는 API를 작성
작성 중인 RequestDto앞에 목적을 나타내도록 네이밍 수정 -> dto 명이 너무 불확실해서 헷갈려서...

Closes #28 