### PR TITLE
Feature/#37 레시피 상세 조회 수정

### DIFF
--- a/src/main/java/com/hackathonteam1/refreshrator/dto/response/recipe/DetailRecipeDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/response/recipe/DetailRecipeDto.java
@@ -1,7 +1,6 @@
 package com.hackathonteam1.refreshrator.dto.response.recipe;
 
-import com.hackathonteam1.refreshrator.dto.response.ingredient.IngredientDto;
-import com.hackathonteam1.refreshrator.entity.Ingredient;
+import com.hackathonteam1.refreshrator.entity.IngredientRecipe;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,12 +13,12 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class DetailRecipeDto {
     private String name;
-    private List<IngredientDto> ingredients;
+    private List<IngredientRecipeResponseDto> ingredientRecipes;
     private String cookingStep;
 
-    public static DetailRecipeDto detailRecipeDto(String name, List<Ingredient> ingredients, String cookingStep){
-        List<IngredientDto> ingredientDtos = ingredients.stream().map(
-                i->IngredientDto.changeToDto(i)).collect(Collectors.toList());
+    public static DetailRecipeDto detailRecipeDto(String name, List<IngredientRecipe> ingredientRecipes, String cookingStep){
+        List<IngredientRecipeResponseDto> ingredientDtos = ingredientRecipes.stream().map(
+                i->IngredientRecipeResponseDto.changeToDto(i)).collect(Collectors.toList());
         return new DetailRecipeDto(name, ingredientDtos, cookingStep);
     }
 }

--- a/src/main/java/com/hackathonteam1/refreshrator/dto/response/recipe/IngredientRecipeResponseDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/response/recipe/IngredientRecipeResponseDto.java
@@ -1,0 +1,22 @@
+package com.hackathonteam1.refreshrator.dto.response.recipe;
+
+import com.hackathonteam1.refreshrator.dto.response.ingredient.IngredientDto;
+import com.hackathonteam1.refreshrator.entity.Ingredient;
+import com.hackathonteam1.refreshrator.entity.IngredientRecipe;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class IngredientRecipeResponseDto {
+
+    private UUID id;
+    private IngredientDto ingredient;
+
+    public static IngredientRecipeResponseDto changeToDto(IngredientRecipe ingredientRecipe){
+        return new IngredientRecipeResponseDto(ingredientRecipe.getId(), IngredientDto.changeToDto(ingredientRecipe.getIngredient()));
+    }
+
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/service/RecipeServiceImpl.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/service/RecipeServiceImpl.java
@@ -52,10 +52,7 @@ public class RecipeServiceImpl implements RecipeService{
         Recipe recipe = findRecipeByRecipeId(recipeId);
         List<IngredientRecipe> ingredientRecipes = findAllIngredientRecipeByRecipe(recipe);
 
-        List<Ingredient> ingredients = findAllIngredientByIngredientRecipes(ingredientRecipes);
-
-        DetailRecipeDto detailRecipeDto = DetailRecipeDto.detailRecipeDto(recipe.getName(),ingredients, recipe.getCookingStep());
-
+        DetailRecipeDto detailRecipeDto = DetailRecipeDto.detailRecipeDto(recipe.getName(),ingredientRecipes, recipe.getCookingStep());
         return detailRecipeDto;
     }
 


### PR DESCRIPTION
## Description
레시피 상세 조회 시 레시피 재료의 Id를 조회할 수 있도록 중간 Dto를 추가함

## Changes
- [x] RecipeServiceImpl
- [x] IngredientRecipeReponseDto
- [x] DetailRecipeDto

## Additional context
IngredientRecipeReponseDto를 추가하여 
레시피 상세 Dto > 레시피 재료 Dto > 재료 Dto의 형태로 Reponse됨. ('>'는 포함한다는 것을 의미)
 
Closes #37 