### PR TITLE
Feature/#43 엔티티 수정 

### DIFF
--- a/src/main/java/com/hackathonteam1/refreshrator/controller/AuthController.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/controller/AuthController.java
@@ -57,6 +57,8 @@ public class AuthController {
         ResponseCookie cookie = ResponseCookie.from("AccessToken", null)
                 .maxAge(0)
                 .path("/")
+                .httpOnly(true)
+                .sameSite("None").secure(true)
                 .build();
         response.addHeader("set-cookie", cookie.toString());
 

--- a/src/main/java/com/hackathonteam1/refreshrator/entity/Recipe.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/entity/Recipe.java
@@ -25,6 +25,9 @@ public class Recipe extends BaseEntity{
     @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<RecipeLike> recipeLikes;
 
+    @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<IngredientRecipe> ingredientRecipes;
+
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "image_id")
     private Image image;

--- a/src/main/java/com/hackathonteam1/refreshrator/entity/RecipeLike.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/entity/RecipeLike.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Entity(name = "like")
+@Entity(name = "recipe_like")
 @Getter
 @Setter
 @NoArgsConstructor


### PR DESCRIPTION
## Description
엔티티 테이블명 변경, 누락된 부분 추가  

## Changes
- [x] Recipe
- [x] RecipeLike

## Additional context
RecipeLike는 쿼리 예약어인 Like와 겹치는 것을 피하고자 엔티티 명을 RecipeLike로 작성했었는데, 처음에 @Entity(name="like")로 작성했던 부분을 놓쳐서 이를 @Entity(name = "recipe_like")로 수정.
Recipe 엔티티 내에 누락된 IngredientRecipe OneToMany필드 추가 

Closes #43 