### PR TITLE
Feature/ #55 레시피 목록 조회 API

### DIFF
--- a/src/main/java/com/hackathonteam1/refreshrator/controller/RecipeController.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/controller/RecipeController.java
@@ -7,6 +7,7 @@ import com.hackathonteam1.refreshrator.dto.request.recipe.RegisterIngredientReci
 import com.hackathonteam1.refreshrator.dto.request.recipe.ModifyRecipeDto;
 import com.hackathonteam1.refreshrator.dto.request.recipe.RegisterRecipeDto;
 import com.hackathonteam1.refreshrator.dto.response.recipe.DetailRecipeDto;
+import com.hackathonteam1.refreshrator.dto.response.recipe.RecipeListDto;
 import com.hackathonteam1.refreshrator.entity.User;
 import com.hackathonteam1.refreshrator.service.RecipeService;
 import jakarta.validation.Valid;
@@ -22,6 +23,13 @@ import java.util.UUID;
 @RequestMapping("/recipes")
 public class RecipeController {
     private final RecipeService recipeService;
+
+    @GetMapping
+    public ResponseEntity<ResponseDto<RecipeListDto>> getList(@RequestParam(name = "keyword",defaultValue = "")String keyword, @RequestParam(name = "type", defaultValue = "newest")String type,
+                                                              @RequestParam(name = "page", defaultValue = "0")int page, @RequestParam(name = "size", defaultValue = "10")int size){
+        RecipeListDto recipeListDto = recipeService.getList(keyword, type, page, size);
+        return new ResponseEntity<>(ResponseDto.res(HttpStatus.OK,"레시피 목록 조회 성공", recipeListDto),HttpStatus.OK);
+    }
 
     @PostMapping
     public ResponseEntity<ResponseDto<Void>> register(
@@ -62,6 +70,5 @@ public class RecipeController {
         recipeService.deleteIngredientRecipe(user, recipeId, deleteIngredientRecipesDto);
         return new ResponseEntity<>(ResponseDto.res(HttpStatus.OK, "레시피 재료 삭제 성공"),HttpStatus.OK);
     }
-
 
 }

--- a/src/main/java/com/hackathonteam1/refreshrator/dto/response/PaginationDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/response/PaginationDto.java
@@ -11,6 +11,6 @@ public class PaginationDto {
     private int totalPage;
 
     public static <T> PaginationDto paginationDto(Page<T> page){
-        return new PaginationDto(page.getNumber(), page.getTotalPages()-1);
+        return new PaginationDto(page.getNumber(), page.getTotalPages());
     }
 }

--- a/src/main/java/com/hackathonteam1/refreshrator/dto/response/PaginationDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/response/PaginationDto.java
@@ -1,0 +1,16 @@
+package com.hackathonteam1.refreshrator.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@AllArgsConstructor
+public class PaginationDto {
+    private int currentPage;
+    private int totalPage;
+
+    public static <T> PaginationDto paginationDto(Page<T> page){
+        return new PaginationDto(page.getNumber(), page.getTotalPages()-1);
+    }
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/dto/response/recipe/RecipeDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/response/recipe/RecipeDto.java
@@ -1,0 +1,16 @@
+package com.hackathonteam1.refreshrator.dto.response.recipe;
+
+import com.hackathonteam1.refreshrator.entity.Recipe;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RecipeDto {
+
+    private String name;
+    private int likeCount;
+    public static RecipeDto mapping(Recipe recipe){
+        return new RecipeDto(recipe.getName(), recipe.getLikeCount());
+    }
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/dto/response/recipe/RecipeListDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/response/recipe/RecipeListDto.java
@@ -1,0 +1,28 @@
+package com.hackathonteam1.refreshrator.dto.response.recipe;
+
+import com.hackathonteam1.refreshrator.dto.response.PaginationDto;
+import com.hackathonteam1.refreshrator.entity.Recipe;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class RecipeListDto {
+    private List<RecipeDto> recipeList;
+    private PaginationDto pagination;
+
+    public static RecipeListDto mapping(Page<Recipe> page){
+        return RecipeListDto.builder()
+                .recipeList(page.stream()
+                        .map((i-> RecipeDto.mapping(i)))
+                        .collect(Collectors.toList()))
+                .pagination(PaginationDto.paginationDto(page))
+                .build();
+    }
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/entity/Image.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/entity/Image.java
@@ -13,7 +13,6 @@ import java.util.UUID;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@ToString(exclude = "recipe")
 public class Image extends BaseEntity{
 
     @Column(nullable = false)

--- a/src/main/java/com/hackathonteam1/refreshrator/entity/Recipe.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/entity/Recipe.java
@@ -2,6 +2,7 @@ package com.hackathonteam1.refreshrator.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Formula;
 
 import java.util.List;
 
@@ -31,6 +32,9 @@ public class Recipe extends BaseEntity{
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "image_id")
     private Image image;
+
+    @Formula("(select count(rl.id) from recipe_like rl where rl.recipe_id = id)")
+    private int likeCount;
 
     public void updateName(String name){
         this.name = name;

--- a/src/main/java/com/hackathonteam1/refreshrator/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/exception/errorcode/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     INGREDIENT_RECIPE_NOT_FOUND("4043", "레시피의 재료를 찾을 수 없습니다."),
     FRIDGE_NOT_FOUND("4044","냉장고를 찾을 수 없습니다"),
     FRIDGE_ITEM_NOT_FOUND("4045","냉장고에 등록된 재료 정보를 찾을 수 없습니다."),
+    PAGE_NOT_FOUND("4046", "페이지를 찾을 수 없습니다"),
 
     //ConflictException
     DUPLICATED_EMAIL("4090", "이미 사용 중인 이메일입니다."),

--- a/src/main/java/com/hackathonteam1/refreshrator/repository/RecipeRepository.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/repository/RecipeRepository.java
@@ -1,9 +1,13 @@
 package com.hackathonteam1.refreshrator.repository;
 
 import com.hackathonteam1.refreshrator.entity.Recipe;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface RecipeRepository extends JpaRepository<Recipe, UUID> {
+    Page<Recipe> findAllByNameContaining(String keyword, Pageable pageable);
+    Page<Recipe> findAll(Pageable pageable);
 }

--- a/src/main/java/com/hackathonteam1/refreshrator/service/RecipeService.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/service/RecipeService.java
@@ -5,12 +5,16 @@ import com.hackathonteam1.refreshrator.dto.request.recipe.RegisterIngredientReci
 import com.hackathonteam1.refreshrator.dto.request.recipe.ModifyRecipeDto;
 import com.hackathonteam1.refreshrator.dto.request.recipe.RegisterRecipeDto;
 import com.hackathonteam1.refreshrator.dto.response.recipe.DetailRecipeDto;
+import com.hackathonteam1.refreshrator.dto.response.recipe.RecipeListDto;
 import com.hackathonteam1.refreshrator.entity.Recipe;
 import com.hackathonteam1.refreshrator.entity.User;
 
 import java.util.UUID;
 
 public interface RecipeService {
+
+    //레시피 목록 조회
+    public RecipeListDto getList(String keyword, String type, int page, int size);
 
     //레시피 등록
     public void register(RegisterRecipeDto registerRecipeDto, User user);


### PR DESCRIPTION
## Description
레시피 목록 조회 API 구현 

## Changes
- [x] RecipeService
- [x] RecipeServiceImpl
- [x] RecipeRepository
- [x] RecipeController
- [x] PaginationDto
- [x] RecipeListDto
- [x] RecipeDto
- [x] Recipe

## Additional context
이미지 부분은 추후 추가할 예정. 
Formula어노테이션을 사용해 조회 시 쿼리를 통해 좋아요 개수를 가져올 수 있도록 설정함. 

### URI
/recipes?type={'newest|popularity'}&keyword={'keyword'}&size={'sizeNum'}&page={'pageNum'}
type: 최신순 | 인기순 정렬
keyword: 레시피명 검색
size: 페이지에 나타나는 레시피 개수
page: 요청하는 페이지 번호 

Closes #55