### PR TITLE
Refactor/#47 DB에 있는 재료 전체 조회 API 삭제

### DIFF
--- a/src/main/java/com/hackathonteam1/refreshrator/controller/IngredientController.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/controller/IngredientController.java
@@ -15,15 +15,8 @@ public class IngredientController {
 
     private final IngredientService ingredientService;
 
-    // DB에 있는 재료 전체 조회
-    @GetMapping()
-    public ResponseEntity<ResponseDto<IngredientListDto>> showAllIngredients() {
-        IngredientListDto ingredientListDto = ingredientService.showAllIngredients();
-        return new ResponseEntity<>(ResponseDto.res(HttpStatus.OK, "모든 재료 조회 성공", ingredientListDto), HttpStatus.OK);
-    }
-
     // DB에 있는 재료 검색
-    @GetMapping("/search")
+    @GetMapping()
     public ResponseEntity<ResponseDto<IngredientListDto>> searchIngredientByName(@RequestParam String name) {
         IngredientListDto ingredientListDto = ingredientService.searchIngredientByName(name);
         return new ResponseEntity<>(ResponseDto.res(HttpStatus.OK, "재료 검색 성공", ingredientListDto), HttpStatus.OK);

--- a/src/main/java/com/hackathonteam1/refreshrator/service/IngredientService.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/service/IngredientService.java
@@ -17,20 +17,6 @@ import java.util.List;
 public class IngredientService {
     private final IngredientRepository ingredientRepository;
 
-    public IngredientListDto showAllIngredients() {
-        List<Ingredient> ingredients = ingredientRepository.findAll();
-        List<IngredientDto> ingredientDtoList = new ArrayList<>();
-
-        for (Ingredient ingredient : ingredients) {
-            IngredientDto ingredientDto = IngredientDto.builder()
-                    .id(ingredient.getId())
-                    .name(ingredient.getName())
-                    .build();
-            ingredientDtoList.add(ingredientDto);
-        }
-        return new IngredientListDto(ingredientDtoList);
-    }
-
     public IngredientListDto searchIngredientByName(String name) {
         List<Ingredient> ingredients = ingredientRepository.findAll();
         List<IngredientDto> ingredientDtoList = new ArrayList<>();

--- a/src/main/java/com/hackathonteam1/refreshrator/service/RecipeServiceImpl.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/service/RecipeServiceImpl.java
@@ -15,7 +15,6 @@ import com.hackathonteam1.refreshrator.entity.IngredientRecipe;
 import com.hackathonteam1.refreshrator.entity.Recipe;
 import com.hackathonteam1.refreshrator.entity.User;
 import com.hackathonteam1.refreshrator.entity.Fridge;
-import com.hackathonteam1.refreshrator.entity.FrdigeItem;
 import com.hackathonteam1.refreshrator.entity.Image;
 
 import com.hackathonteam1.refreshrator.exception.*;


### PR DESCRIPTION
## Description
재료 전체 조회 API 삭제
재료 검색 API의 uri 수정

## Changes
- [x] IngredientController
- [x] IngredientService

## Additional context
재료의 가짓수가 너무 많아서 전체 조회 할 일이 없을 것 같다.
재료 전체 조회는 재료 검색 API에서 검색어를 공백으로 두고 검색하면 모든 재료를 볼 수 있다.
Closed #47 