### PR TITLE
Feature/#90 RecipeDto 내용 추가, 인증 경로 수정

### DIFF
--- a/src/main/java/com/hackathonteam1/refreshrator/authentication/AuthenticationInterceptor.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/authentication/AuthenticationInterceptor.java
@@ -30,6 +30,9 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         if(request.getMethod().equals("OPTIONS")){
             return true;
         }
+        if(request.getMethod().equals("GET") && (request.getRequestURI().equals("/recipes") || request.getRequestURI().matches("^/recipes/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"))){
+            return true;
+        }
         String accessToken = AuthenticationExtractor.extract(request);
         UUID userId = UUID.fromString(jwtTokenProvider.getPayload(accessToken));
         User user = findExistingUser(userId);

--- a/src/main/java/com/hackathonteam1/refreshrator/config/AuthenticationConfig.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/config/AuthenticationConfig.java
@@ -17,12 +17,16 @@ public class AuthenticationConfig implements WebMvcConfigurer {
     private final AuthenticationInterceptor authenticationInterceptor;
     private final AuthenticatedUserArgumentResolver authenticatedUserArgumentResolver;
 
+    private static final String[] ADD_PATH_PATTERNS = {"/fridge/**","/recipes/**","/auth/leave","/auth/logout", "/auth/likes", "/users/me/**"};
+    private static final String[] EXCLUDE_PATH_PATTERNS = {"/auth/signin", "/auth/login"};
+
     //인터셉터 등록 + 경로 설정
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(authenticationInterceptor)
-                .addPathPatterns("/fridge/**","/recipes/**","/auth/leave","/auth/logout", "/auth/likes", "/users/me/**")
-                .excludePathPatterns("/auth/signin", "/auth/login");
+                .addPathPatterns(ADD_PATH_PATTERNS)
+                .excludePathPatterns(EXCLUDE_PATH_PATTERNS);
+
     }
 
     //컨트롤러 메서드 파라미터에 인증된 유저가 들어가도록 함

--- a/src/main/java/com/hackathonteam1/refreshrator/dto/response/recipe/DetailRecipeDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/response/recipe/DetailRecipeDto.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -20,12 +21,16 @@ public class DetailRecipeDto {
     private String name;
     private List<IngredientRecipeResponseDto> ingredientRecipes;
     private String cookingStep;
+    private int likeCount;
     private ImageDto image;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
     public static DetailRecipeDto mapping(Recipe recipe, List<IngredientRecipe> ingredientRecipes){
         List<IngredientRecipeResponseDto> ingredientDtos = ingredientRecipes.stream().map(
                 i->IngredientRecipeResponseDto.changeToDto(i)).collect(Collectors.toList());
         return new DetailRecipeDto(recipe.getId(), recipe.getName(), ingredientDtos,
-                recipe.getCookingStep(),ImageDto.mapping(recipe.getImage()));
+                recipe.getCookingStep(), recipe.getLikeCount(), ImageDto.mapping(recipe.getImage()),
+                recipe.getCreatedAt(), recipe.getUpdatedAt());
     }
 }

--- a/src/main/java/com/hackathonteam1/refreshrator/dto/response/recipe/RecipeDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/response/recipe/RecipeDto.java
@@ -5,6 +5,7 @@ import com.hackathonteam1.refreshrator.entity.Recipe;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
@@ -15,7 +16,10 @@ public class RecipeDto {
     private String name;
     private int likeCount;
     private ImageDto image;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
     public static RecipeDto mapping(Recipe recipe){
-        return new RecipeDto(recipe.getId(), recipe.getName(), recipe.getLikeCount(),ImageDto.mapping(recipe.getImage()));
+        return new RecipeDto(recipe.getId(), recipe.getName(), recipe.getLikeCount(),
+                ImageDto.mapping(recipe.getImage()), recipe.getCreatedAt(), recipe.getUpdatedAt());
     }
 }


### PR DESCRIPTION
## Description
RecipeDto 내용 추가, 인증 경로 수정

## Changes
- [x] AuthenticationConfig
- [x] DetailRecipeDto
- [x] RecipeDto
- [x] AuthenticationInterceptor  
 
## Additional context
유저 인가가 없어도 레시피 상세 조회, 레시피 목록 조회가 가능하도록 수정 -> /recipes와 /recipes/{recipes_id}에는 로그인이 필요없도록 intercepter를 수정
생성 시간, 수정 시간을 추가하고 레시피 상세 조회 시 누락되었던 좋아요 수도 보이도록 수정 

Closes #90 
