### PR TITLE
Feature/#92 refreshtoken 추가.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -63,5 +63,6 @@ jobs: # 실행할 작업들에 대한 설정
             sudo docker pull ${{secrets.DOCKERHUB_USERNAME}}/${{secrets.DOCKERHUB_IMAGE}}
             sudo docker ps -q | xargs -r sudo docker stop
             sudo docker ps -aq | xargs -r sudo docker rm
+            sudo docker run --name redis --rm -d -p 6379:6379 redis
             sudo docker run --name ${{secrets.DOCKERHUB_IMAGE}} --rm -d -p 8080:8080 ${{secrets.DOCKERHUB_USERNAME}}/${{secrets.DOCKERHUB_IMAGE}}
             sudo docker system prune -f

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation 'javax.xml.bind:jaxb-api:2.3.1'//JAXB
 
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'//AWS
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'//Redis
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hackathonteam1/refreshrator/config/AuthenticationConfig.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/config/AuthenticationConfig.java
@@ -18,7 +18,7 @@ public class AuthenticationConfig implements WebMvcConfigurer {
     private final AuthenticatedUserArgumentResolver authenticatedUserArgumentResolver;
 
     private static final String[] ADD_PATH_PATTERNS = {"/fridge/**","/recipes/**","/auth/leave","/auth/logout", "/auth/likes", "/users/me/**"};
-    private static final String[] EXCLUDE_PATH_PATTERNS = {"/auth/signin", "/auth/login"};
+    private static final String[] EXCLUDE_PATH_PATTERNS = {"/auth/signin", "/auth/login", "/auth/refresh"};
 
     //인터셉터 등록 + 경로 설정
     @Override

--- a/src/main/java/com/hackathonteam1/refreshrator/config/RedisConfig.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.hackathonteam1.refreshrator.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisKeyValueAdapter;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    private final String redisHost;
+    private final int redisPort;
+
+    public RedisConfig(@Value("${spring.data.redis.host}") String redisHost,
+                       @Value("${spring.data.redis.port}")int redisPort){
+        this.redisHost = redisHost;
+        this.redisPort = redisPort;
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public <K, V> RedisTemplate<K, V> redisTemplate(RedisConnectionFactory redisConnectionFactory){
+        RedisTemplate<K, V> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer()); //key를 string으로 시리얼라이즈
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer()); //value를 json으로 시리얼라이즈
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer()); //Hash의 key를 String으로 시리얼라이즈
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer()); //Hash의 value를 json으로 시리얼라이즈
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/dto/response/auth/TokenResponseDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/response/auth/TokenResponseDto.java
@@ -1,10 +1,14 @@
 package com.hackathonteam1.refreshrator.dto.response.auth;
 
+import com.hackathonteam1.refreshrator.entity.RefreshToken;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class TokenResponseDto {
     private String AccessToken;
+    private RefreshToken refreshToken;
 }

--- a/src/main/java/com/hackathonteam1/refreshrator/entity/RefreshToken.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/entity/RefreshToken.java
@@ -1,0 +1,22 @@
+package com.hackathonteam1.refreshrator.entity;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.index.Indexed;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RefreshToken {
+    @Id
+    private UUID tokenId;
+    @Indexed
+    private UUID userId;
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/exception/RedisException.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/exception/RedisException.java
@@ -1,0 +1,9 @@
+package com.hackathonteam1.refreshrator.exception;
+
+import com.hackathonteam1.refreshrator.exception.errorcode.ErrorCode;
+
+public class RedisException extends CustomException{
+    public RedisException(ErrorCode errorCode, String detail) {
+        super(errorCode, detail);
+    }
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/exception/errorcode/ErrorCode.java
@@ -47,7 +47,8 @@ public enum ErrorCode {
     RECIPE_IMAGE_CONFLICT("4093", "레시피에 이미지가 이미 존재합니다."),
 
     //InternetException
-    FILE_STORAGE_ERROR("5000", "파일을 업로드할 수 없습니다.");
+    FILE_STORAGE_ERROR("5000", "파일을 업로드할 수 없습니다."),
+    REDIS_ERROR("5001", "Redis에서 오류가 발생했습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/hackathonteam1/refreshrator/service/AuthService.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/service/AuthService.java
@@ -172,7 +172,7 @@ public class AuthService {
 
     private RefreshToken findRefreshTokenByRefreshTokenId(UUID tokenId){
         return redisUtilForRefreshToken.findById(tokenId.toString()).orElseThrow( () ->
-                new UnauthorizedException(ErrorCode.INVALID_TOKEN));
+                new UnauthorizedException(ErrorCode.INVALID_TOKEN, "유효하지 않은 RefreshToken입니다."));
     }
 
     private <T> void checkValidPage(Page<T> pages, int page){

--- a/src/main/java/com/hackathonteam1/refreshrator/util/RedisUtil.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/util/RedisUtil.java
@@ -1,0 +1,40 @@
+package com.hackathonteam1.refreshrator.util;
+
+
+import com.hackathonteam1.refreshrator.exception.RedisException;
+import com.hackathonteam1.refreshrator.exception.errorcode.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class RedisUtil<K, V> {
+    private final RedisTemplate<K, V> redisTemplate;
+
+    public void save(K key, V value, long timeout, TimeUnit timeUnit) {
+        try {
+            redisTemplate.opsForValue().set(key, value, timeout, timeUnit);
+        } catch (Exception e) {
+            throw new RedisException( ErrorCode.REDIS_ERROR, e.getMessage());
+        }
+    }
+
+    public void delete(K key) {
+        try {
+            redisTemplate.delete(key);
+        }catch (Exception e){
+            throw new RedisException( ErrorCode.REDIS_ERROR, e.getMessage());
+        }
+    }
+
+    public Optional<V> findById(K key){
+        V result = redisTemplate.opsForValue().get(key);
+        return Optional.ofNullable(result);
+    }
+}


### PR DESCRIPTION
## Description
RefreshToken 기능 추가

## Changes
- [x] gradle.yml
- [x] RedisConfig
- [x] RedisUtil
- [x] RedisException
- [x] RefreshToken
- [x] AuthController
- [x] AuthService 

## Additional context
refreshToken 기능 추가. 기한은 14일이며 accessToken 재발급 받을 때마다 refreshToken도 재발급받는 형식(RTR).
refreshToken은 휘발성 인메모리인 redis에서 관리한다.
유저는 refreshToken을 하나만 가질 수 있는 형태. 다른 브라우저나 환경에서 로그인 할 경우 기존의 리프레쉬 토큰은 유효하지 않게 됨

Closes #92 