### PR TITLE
Feature/#104 레시피 리팩토링 

### DIFF
--- a/src/main/java/com/hackathonteam1/refreshrator/dto/response/recipe/DetailRecipeDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/response/recipe/DetailRecipeDto.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 public class DetailRecipeDto {
     private UUID id;
     private String name;
+    private String writer;
     private List<IngredientRecipeResponseDto> ingredientRecipes;
     private String cookingStep;
     private int likeCount;
@@ -29,7 +30,7 @@ public class DetailRecipeDto {
     public static DetailRecipeDto mapping(Recipe recipe, List<IngredientRecipe> ingredientRecipes){
         List<IngredientRecipeResponseDto> ingredientDtos = ingredientRecipes.stream().map(
                 i->IngredientRecipeResponseDto.changeToDto(i)).collect(Collectors.toList());
-        return new DetailRecipeDto(recipe.getId(), recipe.getName(), ingredientDtos,
+        return new DetailRecipeDto(recipe.getId(), recipe.getName(), recipe.getUser().getName(), ingredientDtos,
                 recipe.getCookingStep(), recipe.getLikeCount(), ImageDto.mapping(recipe.getImage()),
                 recipe.getCreatedAt(), recipe.getUpdatedAt());
     }

--- a/src/main/java/com/hackathonteam1/refreshrator/entity/Recipe.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/entity/Recipe.java
@@ -20,8 +20,7 @@ public class Recipe extends BaseEntity{
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
-    @Lob
+    @Column(nullable = false, length = 5000)
     private String cookingStep;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)


### PR DESCRIPTION
## Description
레시피 리팩토링

## Changes
- [x] Recipe
- [x] RecipeServiceImpl 
- [x] RecipeDetailDto 

## Additional context
- 레시피 조리법 필드를 5000자로 수정
- 등록가능한 레시피 이미지 파일 확장자를 종류를 추가 jpg, jpeg, gif, png -> jpg, jpeg, png, gif, webp, bmp, tiff, svg, heic
- 레시피 상세 조회 시 작성자 조회 가능하도록 수정 
- 레시피 등록 시 동일한 재료를 보내면 자동으로 하나만 들어가도록 수정

Closes #104 