### PR TITLE
Feature/#107 회원 탈퇴 시 해당 회원이 작성한 레시피 삭제되도록 수정 

### DIFF
--- a/src/main/java/com/hackathonteam1/refreshrator/entity/Recipe.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/entity/Recipe.java
@@ -6,6 +6,8 @@ import io.micrometer.common.lang.Nullable;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Formula;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.util.List;
 
@@ -24,6 +26,7 @@ public class Recipe extends BaseEntity{
     private String cookingStep;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
     private User user;
 
     @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
@@ -35,6 +38,7 @@ public class Recipe extends BaseEntity{
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "image_id")
     @Nullable
+    @OnDelete(action =  OnDeleteAction.SET_NULL)
     private Image image;
 
     @Formula("(select count(rl.id) from recipe_like rl where rl.recipe_id = id)")

--- a/src/main/java/com/hackathonteam1/refreshrator/entity/User.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/entity/User.java
@@ -24,7 +24,7 @@ public class User extends BaseEntity{
     @Column(nullable = false)
     private String password;
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL,orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Recipe> recipes;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)

--- a/src/main/java/com/hackathonteam1/refreshrator/repository/RecipeRepository.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/repository/RecipeRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -19,4 +21,6 @@ public interface RecipeRepository extends JpaRepository<Recipe, UUID> {
     Page<Recipe> findAllByIngredientRecipesContain(@Param("ingredients") Set<Ingredient> ingredients, @Param("match") int match, Pageable pageable);
     Page<Recipe> findAll(Pageable pageable);
     Page<Recipe> findAllByUser(User user, Pageable pageable);
+
+    Optional<List<Recipe>> findAllByUser(User user);
 }


### PR DESCRIPTION
## Description
회원 탈퇴 시 해당 회원이 작성한 레시피 삭제되도록 수정 

## Changes
- [x] User
- [x] AuthService 

## Additional context
기존엔 유저 탈퇴 시에도 레시피는 삭제되지 않고 남아있도록 했었던 걸, 유저 탈퇴 시 해당 유저가 작성했던 레시피가 삭제되도록 수정 

Closes #107