### PR TITLE
Feature/#118 인증 경로 수정, UriMatcher 유틸 클래스 작성, 인터셉터 리팩토링  

### DIFF
--- a/src/main/java/com/hackathonteam1/refreshrator/authentication/AuthenticationInterceptor.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/authentication/AuthenticationInterceptor.java
@@ -1,18 +1,21 @@
 package com.hackathonteam1.refreshrator.authentication;
 
+
 import com.hackathonteam1.refreshrator.entity.User;
-import com.hackathonteam1.refreshrator.exception.NotFoundException;
 import com.hackathonteam1.refreshrator.exception.UnauthorizedException;
 import com.hackathonteam1.refreshrator.exception.errorcode.ErrorCode;
 import com.hackathonteam1.refreshrator.repository.UserRepository;
+import com.hackathonteam1.refreshrator.util.UriMatcher;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import java.util.UUID;
+import java.util.*;
 
 @Component
 @RequiredArgsConstructor
@@ -22,17 +25,23 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationContext authenticationContext;
     private final UserRepository userRepository;
+    private final static Set<String> EXCLUDE_RECIPES_PATTENS = new HashSet<>(Arrays.asList("/recipes/recommendations"));
 
     @Override
     public boolean preHandle(final HttpServletRequest request,
                              final HttpServletResponse response,
                              final Object handler) {
-        if(request.getMethod().equals("OPTIONS")){
+
+        if(CorsUtils.isPreFlightRequest(request)){ //preflight OPTIONS 요청을 위함.
             return true;
         }
-        if(request.getMethod().equals("GET") && (request.getRequestURI().equals("/recipes") || request.getRequestURI().matches("^/recipes/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"))){
-            return true;
-        }
+
+        UriMatcher recipeListUriMatcher = new UriMatcher(HttpMethod.GET, "/recipes");
+        UriMatcher recipeDetailUriMatcher = new UriMatcher(HttpMethod.GET, "/recipes/{id}");
+
+        if(recipeListUriMatcher.match(request)) return true; //Request 경로가 UriMatcher와 일치한다면 통과.
+        if(recipeDetailUriMatcher.matchWithExclusion(request, EXCLUDE_RECIPES_PATTENS)) return true; //Request 경로가 제외 패턴에 해당하지않고 UriMatcher와 일치한다면 통과.
+
         String accessToken = AuthenticationExtractor.extract(request);
         UUID userId = UUID.fromString(jwtTokenProvider.getPayload(accessToken));
         User user = findExistingUser(userId);

--- a/src/main/java/com/hackathonteam1/refreshrator/config/AuthenticationConfig.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/config/AuthenticationConfig.java
@@ -17,15 +17,26 @@ public class AuthenticationConfig implements WebMvcConfigurer {
     private final AuthenticationInterceptor authenticationInterceptor;
     private final AuthenticatedUserArgumentResolver authenticatedUserArgumentResolver;
 
-    private static final String[] ADD_PATH_PATTERNS = {"/fridge/**","/recipes/**","/auth/leave","/auth/logout", "/auth/likes", "/users/me/**"};
-    private static final String[] EXCLUDE_PATH_PATTERNS = {"/auth/signin", "/auth/login", "/auth/refresh"};
+    private static final String[] ADD_PATH_PATTERNS_AUTH = {
+            "/auth/leave","/auth/logout", "/auth/likes",
+    };
+    private static final String[] ADD_PATH_PATTERNS_RECIPE = {
+            "/recipes", "/recipes/*", "/recipes/recommendations/*", "/recipes/images/*", "/recipes/*/ingredients", "/recipes/{id}/likes"
+    };
+    private static final String[] ADD_PATH_PATTERNS_FRIDGE = { "/fridge/ingredients/*", "/fridge/ingredients"};
+    private static final String[] ADD_PATH_PATTERNS_USER = {"/users/me/recipe"};
+
+    private static final String[] EXCLUDE_PATH_PATTERNS_AUTH = {"/auth/signin", "/auth/login", "/auth/refresh"};
 
     //인터셉터 등록 + 경로 설정
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(authenticationInterceptor)
-                .addPathPatterns(ADD_PATH_PATTERNS)
-                .excludePathPatterns(EXCLUDE_PATH_PATTERNS);
+                .addPathPatterns(ADD_PATH_PATTERNS_RECIPE)
+                .addPathPatterns(ADD_PATH_PATTERNS_FRIDGE)
+                .addPathPatterns(ADD_PATH_PATTERNS_AUTH)
+                .addPathPatterns(ADD_PATH_PATTERNS_USER)
+                .excludePathPatterns(EXCLUDE_PATH_PATTERNS_AUTH);
 
     }
 

--- a/src/main/java/com/hackathonteam1/refreshrator/config/AuthenticationConfig.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/config/AuthenticationConfig.java
@@ -21,11 +21,10 @@ public class AuthenticationConfig implements WebMvcConfigurer {
             "/auth/leave","/auth/logout", "/auth/likes",
     };
     private static final String[] ADD_PATH_PATTERNS_RECIPE = {
-            "/recipes", "/recipes/*", "/recipes/recommendations/*", "/recipes/images/*", "/recipes/*/ingredients", "/recipes/{id}/likes"
+            "/recipes", "/recipes/{id}", "/recipes/recommendations", "/recipes/images", "/recipes/images/{id}", "/recipes/{id}/ingredients", "/recipes/{id}/likes"
     };
-    private static final String[] ADD_PATH_PATTERNS_FRIDGE = { "/fridge/ingredients/*", "/fridge/ingredients"};
+    private static final String[] ADD_PATH_PATTERNS_FRIDGE = { "/fridge/ingredients", "/fridge/ingredients/{id}"};
     private static final String[] ADD_PATH_PATTERNS_USER = {"/users/me/recipe"};
-
     private static final String[] EXCLUDE_PATH_PATTERNS_AUTH = {"/auth/signin", "/auth/login", "/auth/refresh"};
 
     //인터셉터 등록 + 경로 설정

--- a/src/main/java/com/hackathonteam1/refreshrator/util/UriMatcher.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/util/UriMatcher.java
@@ -1,0 +1,26 @@
+package com.hackathonteam1.refreshrator.util;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.util.UriTemplate;
+
+import java.util.Collection;
+
+@AllArgsConstructor
+public class UriMatcher {
+    private final HttpMethod method;
+    private final String path;
+
+    public boolean matchWithExclusion(HttpServletRequest request, Collection<String> excludePatterns){
+        if(excludePatterns.stream().anyMatch(i->i.equals(request.getRequestURI()))) return false;
+        UriTemplate uriTemplate = new UriTemplate(path);
+        return method.matches(request.getMethod()) && uriTemplate.matches(request.getRequestURI());
+    }
+
+    public boolean match(HttpServletRequest request){
+        UriTemplate uriTemplate = new UriTemplate(path);
+        return method.matches(request.getMethod()) && uriTemplate.matches(request.getRequestURI());
+    }
+}


### PR DESCRIPTION
## Description
등록된 경로 수정 및  UriMatcher 유틸 클래스 작성, 인터셉터 리팩토링

## Changes
- [x] AuthenticationInterceptor
- [x] UriMatcher
- [x] AuthenticationConfig

## Additional context
GET요청으로 들어오는 레시피 관련 경로 중 인증이 필요한 경우와 그렇지 않은 경우를 분리함.
- 인증 필요 /recipes/{recipe_id} 
- 인증 불필요 /recipes/recommendation
이를 UriMatcher 클래스를 작성하여 분리.

Closes #118 