### PR TITLE
Feature/#124 이미지 서비스 리팩토링

### DIFF
--- a/src/main/java/com/hackathonteam1/refreshrator/controller/RecipeController.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/controller/RecipeController.java
@@ -10,6 +10,7 @@ import com.hackathonteam1.refreshrator.dto.response.file.ImageDto;
 import com.hackathonteam1.refreshrator.dto.response.recipe.DetailRecipeDto;
 import com.hackathonteam1.refreshrator.dto.response.recipe.RecipeListDto;
 import com.hackathonteam1.refreshrator.entity.User;
+import com.hackathonteam1.refreshrator.service.ImageService;
 import com.hackathonteam1.refreshrator.service.RecipeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,7 @@ import java.util.UUID;
 @RequestMapping("/recipes")
 public class RecipeController {
     private final RecipeService recipeService;
+    private final ImageService imageService;
 
     @GetMapping
     public ResponseEntity<ResponseDto<RecipeListDto>> getList(@RequestParam(name = "keyword",defaultValue = "")String keyword, @RequestParam(name = "type", defaultValue = "newest")String type,
@@ -102,14 +104,14 @@ public class RecipeController {
     @PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE )
     public ResponseEntity<ResponseDto<ImageDto>> registerFile(
             @RequestPart MultipartFile file){
-        ImageDto imageDto =  recipeService.registerImage(file);
+        ImageDto imageDto =  imageService.registerImage(file);
         return new ResponseEntity<>(ResponseDto.res(HttpStatus.OK, "이미지 등록 성공", imageDto),HttpStatus.OK);
     }
 
     @DeleteMapping(value = "/images/{image_Id}")
     public ResponseEntity<ResponseDto<Void>> deleteFile(
             @PathVariable UUID image_Id,@AuthenticatedUser User user){
-        recipeService.deleteImage(image_Id, user);
+        imageService.deleteImage(image_Id, user);
         return new ResponseEntity<>(ResponseDto.res(HttpStatus.OK, "이미지 삭제 성공"),HttpStatus.OK);
 
     }

--- a/src/main/java/com/hackathonteam1/refreshrator/dto/request/recipe/ModifyRecipeDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/request/recipe/ModifyRecipeDto.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+
 
 import java.util.UUID;
 
@@ -20,4 +20,6 @@ public class ModifyRecipeDto {
     private String cookingStep;
 
     private UUID imageId;
+
+    private UUID deleteImageId;
 }

--- a/src/main/java/com/hackathonteam1/refreshrator/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/exception/errorcode/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
     NOT_NULL("4005", "필수값이 공백입니다."),
     DUPLICATED_RECIPE_INGREDIENT("4006","중복되는 레시피 재료 관련 요청은 불가합니다."),
     FILE_TYPE_ERROR("4007", "유효하지 않은 파일 형식입니다."),
-    IMAGE_NOT_OF_RECIPE("4008", "해당 레시피의 이미지 요청이 아닙니다."),
+    NOT_IMAGE_OF_RECIPE("4008", "해당 레시피의 이미지 요청이 아닙니다."),
     SORT_TYPE_ERROR("4009", "정렬 타입이 유효하지 않습니다."),
 
     //AuthorizedException

--- a/src/main/java/com/hackathonteam1/refreshrator/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/exception/errorcode/ErrorCode.java
@@ -1,6 +1,5 @@
 package com.hackathonteam1.refreshrator.exception.errorcode;
 
-import com.hackathonteam1.refreshrator.entity.Recipe;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -17,7 +16,7 @@ public enum ErrorCode {
     NOT_NULL("4005", "필수값이 공백입니다."),
     DUPLICATED_RECIPE_INGREDIENT("4006","중복되는 레시피 재료 관련 요청은 불가합니다."),
     FILE_TYPE_ERROR("4007", "유효하지 않은 파일 형식입니다."),
-    IMAGE_NOT_IN_RECIPE("4008", "이미지가 존재하지 않는 레시피입니다."),
+    IMAGE_NOT_OF_RECIPE("4008", "해당 레시피의 이미지 요청이 아닙니다."),
     SORT_TYPE_ERROR("4009", "정렬 타입이 유효하지 않습니다."),
 
     //AuthorizedException
@@ -39,7 +38,6 @@ public enum ErrorCode {
     PAGE_NOT_FOUND("4046", "페이지를 찾을 수 없습니다"),
     IMAGE_NOT_FOUND("4047","이미지를 찾을 수 없습니다"),
     RECIPE_LIKE_NOT_FOUND("4048", "좋아요를 누른 레시피가 아닙니다."),
-
 
     //ConflictException
     DUPLICATED_EMAIL("4090", "이미 사용 중인 이메일입니다."),

--- a/src/main/java/com/hackathonteam1/refreshrator/service/AuthService.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/service/AuthService.java
@@ -37,9 +37,8 @@ public class AuthService {
     private final PasswordHashEncryption passwordHashEncryption;
     private final JwtTokenProvider jwtTokenProvider;
     private final RecipeLikeRepository recipeLikeRepository;
-    private final S3Uploader s3Uploader;
     private final ImageRepository imageRepository;
-    private final RecipeRepository recipeRepository;
+    private final ImageService imageService;
 
     private final RedisUtil<String, RefreshToken> redisUtilForRefreshToken;
     private final RedisUtil<String, String> redisUtilForUserId;
@@ -80,14 +79,7 @@ public class AuthService {
     public void leave(User user){
         //레시피를 삭제하기 전, 유저의 레시피 내 이미지를 S3에서 모두 삭제
         if(user.getRecipes()!=null){
-            List<Recipe> recipes = findAllRecipesByUser(user);
-
-            recipes.forEach(recipe-> {
-                if(recipe.isContainingImage()){
-                    Image image = findImageByRecipe(recipe);
-                    s3Uploader.removeS3FileByUrl(image.getUrl());
-                }
-            });
+            imageService.deleteAllImagesOfUser(user);
         }
         //탈퇴
         userRepository.delete(user);
@@ -197,9 +189,5 @@ public class AuthService {
 
     private Image findImageByRecipe(Recipe recipe){
         return imageRepository.findByRecipe(recipe).orElseThrow(()->new NotFoundException(ErrorCode.IMAGE_NOT_FOUND));
-    }
-
-    private List<Recipe> findAllRecipesByUser(User user){
-        return recipeRepository.findAllByUser(user).orElseThrow(()-> new NotFoundException(ErrorCode.RECIPE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/hackathonteam1/refreshrator/service/ImageService.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/service/ImageService.java
@@ -1,0 +1,27 @@
+package com.hackathonteam1.refreshrator.service;
+
+import com.hackathonteam1.refreshrator.dto.response.file.ImageDto;
+import com.hackathonteam1.refreshrator.entity.Image;
+import com.hackathonteam1.refreshrator.entity.Recipe;
+import com.hackathonteam1.refreshrator.entity.User;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+public interface ImageService{
+    //파일(이미지) 등록
+    public ImageDto registerImage(MultipartFile file);
+
+    //파일(이미지) 삭제
+    public void deleteImage(UUID imageId, User user);
+
+    //이미지Id로 이미지 찾기
+    public Image findImageById(UUID imageId);
+
+    //레시피로 이미지 찾기
+    public Image findImageByRecipe(Recipe recipe);
+
+    //유저의 레시피 내 S3 이미지들을 전부 삭제
+    public void deleteAllImagesOfUser(User user);
+
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/service/ImageServiceImpl.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/service/ImageServiceImpl.java
@@ -1,0 +1,99 @@
+package com.hackathonteam1.refreshrator.service;
+
+import com.hackathonteam1.refreshrator.dto.response.file.ImageDto;
+import com.hackathonteam1.refreshrator.entity.Image;
+import com.hackathonteam1.refreshrator.entity.Recipe;
+import com.hackathonteam1.refreshrator.entity.User;
+import com.hackathonteam1.refreshrator.exception.BadRequestException;
+import com.hackathonteam1.refreshrator.exception.FileStorageException;
+import com.hackathonteam1.refreshrator.exception.NotFoundException;
+import com.hackathonteam1.refreshrator.exception.errorcode.ErrorCode;
+import com.hackathonteam1.refreshrator.repository.ImageRepository;
+import com.hackathonteam1.refreshrator.repository.RecipeRepository;
+import com.hackathonteam1.refreshrator.util.S3Uploader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ImageServiceImpl implements ImageService{
+
+    private final ImageRepository imageRepository;
+    private final S3Uploader s3Uploader;
+    private final RecipeRepository recipeRepository;
+
+    private static final List<String> IMAGE_EXTENSION = Arrays.asList(".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff", ".svg", ".heic");
+
+
+    @Override
+    public ImageDto registerImage(MultipartFile file) {
+
+        validateImageFile(file); //확장자를 통해 이미지 파일인지 확인
+
+        String url = uplaodFileToS3(file);
+
+        Image image = Image.builder()
+                .url(url)
+                .build();
+
+        imageRepository.save(image);
+        ImageDto imageDto = ImageDto.mapping(image);
+        return imageDto;
+    }
+
+    @Override
+    public void deleteImage(UUID imageId, User user) {
+        Image image = findImageById(imageId);
+        s3Uploader.removeS3FileByUrl(image.getUrl());
+        imageRepository.delete(image);
+    }
+
+    @Override
+    public Image findImageById(UUID imageId){
+        return imageRepository.findById(imageId).orElseThrow(()->new NotFoundException(ErrorCode.IMAGE_NOT_FOUND));
+    }
+
+    @Override
+    public Image findImageByRecipe(Recipe recipe){
+        return imageRepository.findByRecipe(recipe).orElseThrow(()->new NotFoundException(ErrorCode.IMAGE_NOT_FOUND));
+    }
+
+    @Override
+    @CacheEvict(value = "recipeListCache", allEntries = true, cacheManager = "redisCacheManager")
+    public void deleteAllImagesOfUser(User user) {
+        List<Recipe> recipes = findAllRecipesByUser(user);
+
+        recipes.forEach(recipe-> {
+            if(recipe.isContainingImage()){
+                Image image = findImageByRecipe(recipe);
+                s3Uploader.removeS3FileByUrl(image.getUrl());
+            }
+        });
+    }
+
+    private void validateImageFile(MultipartFile file){
+        String lowerFileName = file.getOriginalFilename().toLowerCase();
+        if(!IMAGE_EXTENSION.stream().anyMatch(i-> lowerFileName.endsWith(i))){
+            throw new FileStorageException(ErrorCode.FILE_TYPE_ERROR);
+        };
+    }
+
+    private String uplaodFileToS3(MultipartFile file){
+        try {
+            return s3Uploader.upload(file);
+        } catch (IOException e) {
+            throw new FileStorageException(ErrorCode.FILE_STORAGE_ERROR, e.getMessage());
+        }
+    }
+
+    private List<Recipe> findAllRecipesByUser(User user){
+        return recipeRepository.findAllByUser(user).orElseThrow(()-> new NotFoundException(ErrorCode.RECIPE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/service/RecipeService.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/service/RecipeService.java
@@ -37,7 +37,6 @@ public interface RecipeService {
     //레시피 재료 삭제
     public void deleteIngredientRecipe(User user, UUID recipeId, DeleteIngredientRecipesDto deleteIngredientRecipesDto);
 
-
     //추천 레시피 목록 조회
     public RecipeListDto getRecommendation(int page, int size, int match, String type, User user);
 
@@ -46,14 +45,8 @@ public interface RecipeService {
 
     // 레시피에 좋아요 삭제
     public void deleteLikeFromRecipe(User user, UUID recipeId);
-  
-    //파일(이미지) 등록
-    public ImageDto registerImage(MultipartFile file);
 
-    //파일(이미지) 삭제
-    public void deleteImage(UUID imageId, User user);
-
-//    자신이 작성한 레시피 조회
+    //자신이 작성한 레시피 조회
     public RecipeListDto findMyRecipes(User user, String type, int page, int size);
 
 }

--- a/src/main/java/com/hackathonteam1/refreshrator/service/RecipeServiceImpl.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/service/RecipeServiceImpl.java
@@ -55,10 +55,10 @@ public class RecipeServiceImpl implements RecipeService{
     private final IngredientRecipeRepository ingredientRecipeRepository;
     private final FridgeRepository fridgeRepository;
     private final S3Uploader s3Uploader;
-    private final ImageRepository imageRepository;
     private final RecipeLikeRepository recipeLikeRepository;
     private final ImageService imageService;
 
+    //레시피 목록 조회
     @Override
     @Cacheable(value = "recipeListCache",key = "#keyword + '-' + #type + '-' + #page + '-' + #size", cacheManager = "redisCacheManager")
     public RecipeListDto getList(String keyword, String type, int page, int size) {
@@ -78,6 +78,7 @@ public class RecipeServiceImpl implements RecipeService{
         return RecipeListDto.mapping(recipePage);
     }
 
+    //레시피 등록
     @Override
     @Transactional
     @CacheEvict(value = "recipeListCache", allEntries = true, cacheManager = "redisCacheManager")

--- a/src/main/java/com/hackathonteam1/refreshrator/service/RecipeServiceImpl.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/service/RecipeServiceImpl.java
@@ -21,7 +21,6 @@ import com.hackathonteam1.refreshrator.exception.*;
 import com.hackathonteam1.refreshrator.exception.errorcode.ErrorCode;
 import com.hackathonteam1.refreshrator.repository.*;
 import com.hackathonteam1.refreshrator.repository.FridgeRepository;
-import com.hackathonteam1.refreshrator.repository.ImageRepository;
 import com.hackathonteam1.refreshrator.repository.IngredientRecipeRepository;
 import com.hackathonteam1.refreshrator.repository.IngredientRepository;
 import com.hackathonteam1.refreshrator.repository.RecipeRepository;
@@ -39,10 +38,8 @@ import org.springframework.data.domain.Sort;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 
-import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -131,7 +128,7 @@ public class RecipeServiceImpl implements RecipeService{
 
         if(modifyRecipeDto.getDeleteImageId()!=null){
             if(!recipe.getImage().getId().equals(modifyRecipeDto.getDeleteImageId())){
-                throw new BadRequestException(ErrorCode.IMAGE_NOT_OF_RECIPE);
+                throw new BadRequestException(ErrorCode.NOT_IMAGE_OF_RECIPE);
             }
             recipe.deleteImage();
         }


### PR DESCRIPTION
## Description
이미지 서비스 리팩토링

## Changes
- [x] AuthService
- [x] RecipeService
- [x] RecipeServiceImpl
- [x] ImageService
- [x] ImageServiceImpl
- [x] ErrorCode
- [x] ModifyRecipeDto

## Additional context
기존에 레시피 서비스에서 수행되던 레시피 이미지 관련 작업을 이미지 서비스를 작성하여 분리.
또한, 레시피 수정 시 ModifyRecipeDto에 deleteImageId 필드를 추가하여 삭제할 이미지 객체 id를 따로 전달해주도록 변경.

분리된 부분은 아래와 같음.
1. 레시피, 이미지 아이디를 통해 이미지를 찾는 메서드
2. 레시피 정보 수정 시 레시피의 이미지 연결 정보는 레시피 서비스에서, S3이미지 삭제는 이미지 서비스에서 이뤄지도록 분리
3. 이미지 등록 부분 이미지 서비스로 분리. 이에 따라 이미지 확장자 검증 로직, S3업로드 로직도 함께 수정됨.

4008 예외에 관해 보다 포괄적인 사용을 위해서 IMAGE_NOT_IN_RECIPE("4008", "이미지가 존재하지 않는 레시피입니다.")를 IMAGE_NOT_OF_RECIPE("4008", "해당 레시피의 이미지 요청이 아닙니다.")로 변경함.

Closes #124 