### PR TITLE
Refactor/#140 로그인시 이메일과 비밀번호 검사를 동시에 하도록 수정

### DIFF
--- a/src/main/java/com/hackathonteam1/refreshrator/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/exception/errorcode/ErrorCode.java
@@ -23,14 +23,13 @@ public enum ErrorCode {
     //AuthorizedException
     COOKIE_NOT_FOUND("4010", "쿠키를 찾을 수 없습니다."),
     INVALID_TOKEN("4011", "유효하지 않은 토큰입니다."),
-    INVALID_PASSWORD("4012","검증되지 않은 비밀번호입니다."),
 
     //ForbiddenException
     RECIPE_FORBIDDEN("4030","해당 레시피에 대한 권한이 없습니다."),
     FRIDGE_ITEM_FORBIDDEN("4031","해당 재료정보에 대한 권한이 없습니다."),
 
     //NotFoundException
-    USER_NOT_FOUND("4040","존재하지 않는 사용자 입니다"),
+    USER_NOT_FOUND("4040","비밀번호에 일치하는 이메일이 존재하지 않습니다."),
     INGREDIENT_NOT_FOUND("4041", "재료를 찾을 수 없습니다."),
     RECIPE_NOT_FOUND("4042", "레시피를 찾을 수 없습니다."),
     INGREDIENT_RECIPE_NOT_FOUND("4043", "레시피의 재료를 찾을 수 없습니다."),

--- a/src/main/java/com/hackathonteam1/refreshrator/repository/UserRepository.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/repository/UserRepository.java
@@ -3,10 +3,9 @@ package com.hackathonteam1.refreshrator.repository;
 import com.hackathonteam1.refreshrator.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
-    User findByEmail(String email);
+    User findByEmailAndPassword(String email,String password);
     Boolean existsByEmail(String email);
 }

--- a/src/main/java/com/hackathonteam1/refreshrator/service/AuthService.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/service/AuthService.java
@@ -49,10 +49,7 @@ public class AuthService {
     public UUID login(LoginDto loginDto){
 
         //아이디(이메일)검사
-        User user=userService.checkUserByEmail(loginDto.getEmail());
-
-        ////비밀번호가 입력한 아이디(이메일)에 일치하는지 검사
-        userService.checkPassword(loginDto.getPassword(), user.getPassword());
+        User user=userService.checkUserByEmail(loginDto.getEmail(), loginDto.getPassword());
 
         return user.getId();
     }

--- a/src/main/java/com/hackathonteam1/refreshrator/service/UserService.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/service/UserService.java
@@ -3,7 +3,6 @@ package com.hackathonteam1.refreshrator.service;
 import com.hackathonteam1.refreshrator.authentication.PasswordHashEncryption;
 import com.hackathonteam1.refreshrator.entity.User;
 import com.hackathonteam1.refreshrator.exception.ConflictException;
-import com.hackathonteam1.refreshrator.exception.ForbiddenException;
 import com.hackathonteam1.refreshrator.exception.NotFoundException;
 import com.hackathonteam1.refreshrator.exception.errorcode.ErrorCode;
 import com.hackathonteam1.refreshrator.repository.UserRepository;
@@ -32,22 +31,16 @@ public class UserService {
     }
 
     //로그인을 위한 아이디(이메일) 검사
-    public User checkUserByEmail(String email){
-        User user=userRepository.findByEmail(email);
+    public User checkUserByEmail(String email,String password){
 
+        String hashedPassword = passwordHashEncryption.encrypt(password);
+
+        User user=userRepository.findByEmailAndPassword(email,hashedPassword);
         if(user==null){
             throw new NotFoundException(ErrorCode.USER_NOT_FOUND);
         }
 
         return user;
-    }
-
-    //비밀번호가 입력한 아이디(이메일)에 일치하는지 검사
-    public void checkPassword(String inputPassword,String UserPassword){
-
-        if(!passwordHashEncryption.matches(inputPassword, UserPassword)){
-            throw new ForbiddenException(ErrorCode.INVALID_PASSWORD);
-        }
     }
 }
 


### PR DESCRIPTION
## Description
로그인 기능에서 이메일검사와 비밀번호검사를 동시에 하도록 변경한다.

## Changes
- [x] loginService
- [x] ErrorCode 변경
- [x] UserRepository에 findByEmailAndPassword추가

## Additional context

close #140 
