### PR TITLE
Feature/#142 검증을 위한 커스텀 어노테이션 추가

### DIFF
--- a/src/main/java/com/hackathonteam1/refreshrator/annotation/Match.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/annotation/Match.java
@@ -1,0 +1,28 @@
+package com.hackathonteam1.refreshrator.annotation;
+
+
+import com.hackathonteam1.refreshrator.annotation.resolver.MatchValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static com.hackathonteam1.refreshrator.constant.ValidatorConstant.MATCH_MAX;
+import static com.hackathonteam1.refreshrator.constant.ValidatorConstant.MATCH_MIN;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = MatchValidator.class)
+public @interface Match {
+
+    String message() default "레시피 추천 시 재료 일치 수는 {min}이상, {max}이하여야 합니다.";
+
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+
+    int min() default MATCH_MIN;
+    int max() default MATCH_MAX;
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/annotation/PageNumber.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/annotation/PageNumber.java
@@ -1,0 +1,25 @@
+package com.hackathonteam1.refreshrator.annotation;
+
+
+import com.hackathonteam1.refreshrator.annotation.resolver.PageNumberValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static com.hackathonteam1.refreshrator.constant.ValidatorConstant.PAGE_NUMBER_MIN;
+
+@Constraint(validatedBy = PageNumberValidator.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface PageNumber {
+    String message() default "페이지 번호는 0이상 이어야 합니다.";
+
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+
+    int min() default PAGE_NUMBER_MIN;
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/annotation/PageSize.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/annotation/PageSize.java
@@ -1,0 +1,26 @@
+package com.hackathonteam1.refreshrator.annotation;
+
+import com.hackathonteam1.refreshrator.annotation.resolver.PageSizeValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static com.hackathonteam1.refreshrator.constant.ValidatorConstant.PAGE_SIZE_MAX;
+import static com.hackathonteam1.refreshrator.constant.ValidatorConstant.PAGE_SIZE_MIN;
+
+@Constraint(validatedBy = PageSizeValidator.class)
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PageSize {
+    String message() default "페이지 크기는 {min}이상, {max}이어야 합니다.";
+
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+
+    int min() default PAGE_SIZE_MIN;
+    int max() default PAGE_SIZE_MAX;
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/annotation/TypeStrategy.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/annotation/TypeStrategy.java
@@ -1,0 +1,24 @@
+package com.hackathonteam1.refreshrator.annotation;
+
+import com.hackathonteam1.refreshrator.annotation.resolver.TypeStrategyValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.HashSet;
+import java.util.Set;
+
+@Constraint(validatedBy = TypeStrategyValidator.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface TypeStrategy {
+    String message() default "정렬 전략이 유효하지 않습니다.";
+
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+
+    String[] strategies() default {"newest", "popularity"};
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/annotation/resolver/MatchValidator.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/annotation/resolver/MatchValidator.java
@@ -1,0 +1,28 @@
+package com.hackathonteam1.refreshrator.annotation.resolver;
+
+import com.hackathonteam1.refreshrator.annotation.Match;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class MatchValidator implements ConstraintValidator<Match, Integer> {
+
+    int min;
+    int max;
+
+    @Override
+    public void initialize(Match constraintAnnotation) {
+        min = constraintAnnotation.min();
+        max = constraintAnnotation.max();
+    }
+
+    @Override
+    public boolean isValid(Integer integer, ConstraintValidatorContext constraintValidatorContext) {
+        if(integer == null){
+            log.info("is null");
+           return false;
+        }
+        return integer>=min && integer<=max;
+    }
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/annotation/resolver/PageNumberValidator.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/annotation/resolver/PageNumberValidator.java
@@ -1,0 +1,24 @@
+package com.hackathonteam1.refreshrator.annotation.resolver;
+
+
+import com.hackathonteam1.refreshrator.annotation.PageNumber;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class PageNumberValidator implements ConstraintValidator<PageNumber, Integer> {
+
+    int min;
+
+    @Override
+    public void initialize(PageNumber constraintAnnotation) {
+        this.min = constraintAnnotation.min();
+    }
+
+    @Override
+    public boolean isValid(Integer integer, ConstraintValidatorContext constraintValidatorContext) {
+        if(integer == null){
+            return false;
+        }
+        return integer >= min;
+    }
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/annotation/resolver/PageSizeValidator.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/annotation/resolver/PageSizeValidator.java
@@ -1,0 +1,28 @@
+package com.hackathonteam1.refreshrator.annotation.resolver;
+
+import com.hackathonteam1.refreshrator.annotation.PageSize;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.lang.annotation.Annotation;
+
+public class PageSizeValidator implements ConstraintValidator<PageSize, Integer> {
+
+    int min;
+    int max;
+
+    @Override
+    public void initialize(PageSize constraintAnnotation) {
+        this.min = constraintAnnotation.min();
+        this.max = constraintAnnotation.max();
+    }
+
+    @Override
+    public boolean isValid(Integer value, ConstraintValidatorContext constraintValidatorContext) {
+        if(value==null){
+            return false;
+        }
+        return value >= min && value <= max;
+    }
+
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/annotation/resolver/TypeStrategyValidator.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/annotation/resolver/TypeStrategyValidator.java
@@ -1,0 +1,27 @@
+package com.hackathonteam1.refreshrator.annotation.resolver;
+
+import com.hackathonteam1.refreshrator.annotation.TypeStrategy;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class TypeStrategyValidator implements ConstraintValidator<TypeStrategy, String> {
+
+    Set<String> strategies;
+
+    @Override
+    public void initialize(TypeStrategy constraintAnnotation) {
+        this.strategies = Arrays.stream(constraintAnnotation.strategies()).collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean isValid(String string, ConstraintValidatorContext constraintValidatorContext) {
+
+        if(string==null || string.isEmpty()) return false;
+
+        return strategies.stream().anyMatch(strategy -> strategy.equals(string));
+    }
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/constant/ParameterDefaultValue.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/constant/ParameterDefaultValue.java
@@ -1,0 +1,8 @@
+package com.hackathonteam1.refreshrator.constant;
+
+public class ParameterDefaultValue {
+    public static final String DEFAULT_PAGE_SIZE = "10";
+    public static final String DEFAULT_PAGE_NUMBER = "0";
+    public static final String DEFAULT_MATCH = "2147483647";
+    public static final String DEFAULT_TYPE_STRATEGY = "newest";
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/constant/RegularExpressionPatterns.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/constant/RegularExpressionPatterns.java
@@ -1,0 +1,8 @@
+package com.hackathonteam1.refreshrator.constant;
+
+public class RegularExpressionPatterns {
+    //아이디(이메일)
+    public static final String EMAIL_PATTERN= "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{1,100}$";
+    //비밀번호
+    public static final String PASSWORD_PATTERN = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()])[A-Za-z\\d!@#$%^&*()]{8,14}$";
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/constant/ValidatorConstant.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/constant/ValidatorConstant.java
@@ -1,0 +1,12 @@
+package com.hackathonteam1.refreshrator.constant;
+
+public class ValidatorConstant {
+
+    public static final int PAGE_SIZE_MIN = 1;
+    public static final int PAGE_SIZE_MAX = 30;
+
+    public static final int PAGE_NUMBER_MIN = 0;
+
+    public static final int MATCH_MIN = 1;
+    public static final int MATCH_MAX = Integer.MAX_VALUE;
+}

--- a/src/main/java/com/hackathonteam1/refreshrator/controller/RecipeController.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/controller/RecipeController.java
@@ -1,6 +1,6 @@
 package com.hackathonteam1.refreshrator.controller;
 
-import com.hackathonteam1.refreshrator.annotation.AuthenticatedUser;
+import com.hackathonteam1.refreshrator.annotation.*;
 import com.hackathonteam1.refreshrator.dto.ResponseDto;
 import com.hackathonteam1.refreshrator.dto.request.recipe.*;
 import com.hackathonteam1.refreshrator.dto.response.file.ImageDto;
@@ -11,8 +11,6 @@ import com.hackathonteam1.refreshrator.entity.User;
 import com.hackathonteam1.refreshrator.service.ImageService;
 import com.hackathonteam1.refreshrator.service.RecipeService;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -21,6 +19,8 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
+
+import static com.hackathonteam1.refreshrator.constant.ParameterDefaultValue.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,9 +31,9 @@ public class RecipeController {
 
     @GetMapping
     public ResponseEntity<ResponseDto<RecipeListDto>> getList(@RequestParam(name = "keyword",defaultValue = "")String keyword,
-                                                              @RequestParam(name = "type", defaultValue = "newest")String type,
-                                                              @Min(0) @RequestParam(name = "page", defaultValue = "0")int page,
-                                                              @Min(1) @Max(30) @RequestParam(name = "size", defaultValue = "10")int size){
+                                                              @TypeStrategy @RequestParam(name = "type", defaultValue = DEFAULT_TYPE_STRATEGY)String type,
+                                                              @PageNumber @RequestParam(name = "page", defaultValue = DEFAULT_PAGE_NUMBER)int page,
+                                                              @PageSize @RequestParam(name = "size", defaultValue = DEFAULT_PAGE_SIZE)int size){
         RecipeListDto recipeListDto = recipeService.getList(keyword, type, page, size);
         return new ResponseEntity<>(ResponseDto.res(HttpStatus.OK,"레시피 목록 조회 성공", recipeListDto),HttpStatus.OK);
     }
@@ -80,10 +80,10 @@ public class RecipeController {
 
     @GetMapping("/recommendations")
     public ResponseEntity<ResponseDto<RecipeListDto>> getRecommendations(
-            @Min(0) @RequestParam(name = "page", defaultValue = "0")int page,
-            @Min(1) @Max(30) @RequestParam(name = "size", defaultValue = "10")int size,
-            @Min(1) @Max(2147483647) @RequestParam(name = "match", defaultValue = "2147483647")int match,
-            @RequestParam(name = "type", defaultValue = "newest")String type,
+            @PageNumber @RequestParam(name = "page", defaultValue = DEFAULT_PAGE_NUMBER)int page,
+            @PageSize @RequestParam(name = "size", defaultValue = DEFAULT_PAGE_SIZE)int size,
+            @Match @RequestParam(name = "match", defaultValue = DEFAULT_MATCH)int match,
+            @TypeStrategy @RequestParam(name = "type", defaultValue = DEFAULT_TYPE_STRATEGY)String type,
             @AuthenticatedUser User user){
         RecipeListDto recipeListDto = recipeService.getRecommendation(page, size, match, type, user);
         return new ResponseEntity<>(ResponseDto.res(HttpStatus.OK,"추천 레시피 목록 조회 성공", recipeListDto),HttpStatus.OK);

--- a/src/main/java/com/hackathonteam1/refreshrator/controller/UserController.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/controller/UserController.java
@@ -1,12 +1,13 @@
 package com.hackathonteam1.refreshrator.controller;
 
 import com.hackathonteam1.refreshrator.annotation.AuthenticatedUser;
+import com.hackathonteam1.refreshrator.annotation.PageNumber;
+import com.hackathonteam1.refreshrator.annotation.PageSize;
+import com.hackathonteam1.refreshrator.annotation.TypeStrategy;
 import com.hackathonteam1.refreshrator.dto.ResponseDto;
 import com.hackathonteam1.refreshrator.dto.response.recipe.RecipeListDto;
 import com.hackathonteam1.refreshrator.entity.User;
 import com.hackathonteam1.refreshrator.service.RecipeService;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.hackathonteam1.refreshrator.constant.ParameterDefaultValue.*;
 
 @RestController
 @AllArgsConstructor
@@ -24,9 +27,9 @@ public class UserController {
 
     @GetMapping("/me/recipes")
     public ResponseEntity<ResponseDto<RecipeListDto>> getMyRecipe(@AuthenticatedUser User user,
-                                                                  @RequestParam(name = "type", defaultValue = "newest") String type,
-                                                                  @Min(0) @RequestParam(name = "page", defaultValue = "0") int page,
-                                                                  @Min(1) @Max(0) @RequestParam(name = "size", defaultValue = "10") int size){
+                                                                  @TypeStrategy @RequestParam(name = "type", defaultValue = DEFAULT_TYPE_STRATEGY) String type,
+                                                                  @PageNumber @RequestParam(name = "page", defaultValue = DEFAULT_PAGE_NUMBER) int page,
+                                                                  @PageSize @RequestParam(name = "size", defaultValue = DEFAULT_PAGE_SIZE) int size){
         RecipeListDto recipeListDto = recipeService.findMyRecipes(user, type, page, size);
         return new ResponseEntity<>(ResponseDto.res(HttpStatus.OK, "자신이 작성한 레시피 목록 조회 성공", recipeListDto),HttpStatus.OK);
     }
@@ -34,8 +37,8 @@ public class UserController {
     // 좋아요 누른 레시피 목록 조회
     @GetMapping("/me/likes")
     public ResponseEntity<ResponseDto<RecipeListDto>> showAllRecipeLikes(@AuthenticatedUser User user,
-                                                                         @Min(0) @RequestParam(name = "page", defaultValue = "0")int page,
-                                                                         @Min(1) @Max(0) @RequestParam(name = "size", defaultValue = "10")int size) {
+                                                                         @PageNumber @RequestParam(name = "page", defaultValue = DEFAULT_PAGE_NUMBER)int page,
+                                                                         @PageSize @RequestParam(name = "size", defaultValue = DEFAULT_PAGE_SIZE)int size) {
         RecipeListDto recipeListDto = recipeService.showAllLikedRecipes(user, page, size);
         return new ResponseEntity<>(ResponseDto.res(HttpStatus.OK, "좋아요 누른 레시피 목록 조회 성공", recipeListDto), HttpStatus.OK);
     }

--- a/src/main/java/com/hackathonteam1/refreshrator/dto/request/auth/LoginDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/request/auth/LoginDto.java
@@ -6,19 +6,22 @@ import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import static com.hackathonteam1.refreshrator.constant.RegularExpressionPatterns.EMAIL_PATTERN;
+import static com.hackathonteam1.refreshrator.constant.RegularExpressionPatterns.PASSWORD_PATTERN;
+
 @Getter
 @AllArgsConstructor
 public class LoginDto {
 
     //아이디(이메일)
-    @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{1,100}$", message = "이메일이 형식에 맞지 않습니다.")
+    @Pattern(regexp = EMAIL_PATTERN, message = "이메일이 형식에 맞지 않습니다.")
     @NotBlank(message = "사용하실 아이디(이메일)을 입력해주세요.")
     @Size(min = 1,max=100,message = "아이디는 최소 한글자 이상 최대 100글자입니다.")
     private String email;
 
     //비밀번호
     @NotBlank(message = "영문과 숫자,특수기호를 조합하여 8~14글자 미만으로 입력하여 주세요.")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()])[A-Za-z\\d!@#$%^&*()]{8,14}$", message = "영문,숫자,특수기호를 조합하여 8~14글자 미만으로 입력하여 주세요.")
+    @Pattern(regexp = PASSWORD_PATTERN, message = "영문,숫자,특수기호를 조합하여 8~14글자 미만으로 입력하여 주세요.")
     @Size(min = 8, max = 14, message = " 비밀번로는 최소8글자 최대 14글자 입니다.")
     private String password;
 }

--- a/src/main/java/com/hackathonteam1/refreshrator/dto/request/auth/SigninDto.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/dto/request/auth/SigninDto.java
@@ -6,6 +6,9 @@ import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import static com.hackathonteam1.refreshrator.constant.RegularExpressionPatterns.EMAIL_PATTERN;
+import static com.hackathonteam1.refreshrator.constant.RegularExpressionPatterns.PASSWORD_PATTERN;
+
 @Getter
 @AllArgsConstructor
 public class SigninDto {
@@ -15,14 +18,14 @@ public class SigninDto {
     private String name;
 
     //아이디(이메일)
-    @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{1,100}$", message = "이메일이 형식에 맞지 않습니다.")
+    @Pattern(regexp = EMAIL_PATTERN, message = "이메일이 형식에 맞지 않습니다.")
     @NotBlank(message = "사용하실 아이디(이메일)을 입력해주세요.")
     @Size(min = 1,max=100,message = "아이디는 최소 한글자 이상 최대 100글자입니다.")
     private String email;
 
     //비밀번호
     @NotBlank(message = "영문과 숫자,특수기호를 조합하여 8~14글자 미만으로 입력하여 주세요.")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()])[A-Za-z\\d!@#$%^&*()]{8,14}$", message = "영문,숫자,특수기호를 조합하여 8~14글자 미만으로 입력하여 주세요.")
+    @Pattern(regexp = PASSWORD_PATTERN, message = "영문,숫자,특수기호를 조합하여 8~14글자 미만으로 입력하여 주세요.")
     @Size(min = 8, max = 14, message = " 비밀번로는 최소8글자 최대 14글자 입니다.")
     private String password;
 

--- a/src/main/java/com/hackathonteam1/refreshrator/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/hackathonteam1/refreshrator/exception/errorcode/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     NOT_IMAGE_OF_RECIPE("4008", "해당 레시피의 이미지 요청이 아닙니다."),
     SORT_TYPE_ERROR("4009", "정렬 타입이 유효하지 않습니다."),
     STORAGE_ERROR("40010","저장 방법이 올바르지 않습니다."),
+    INVALID_REQUEST_PARAMETER("40011", "요청 파라미터 값이 유효하지 않습니다."),
 
     //AuthorizedException
     COOKIE_NOT_FOUND("4010", "쿠키를 찾을 수 없습니다."),


### PR DESCRIPTION
## Description
검증을 위한 커스텀 어노테이션 추가

## Changes

### Controller
- [x] RecipeController
- [x] UserController
- [x] ExceptionController

### Annotation
- [x] PageSize
- [x] PageSizeValidator
- [x] PageNumber
- [x] PageNumberValidator
- [x] Match
- [x] MatchValidator
- [x] TargetStrategy
- [x] TargetStrategyValidator 

## Additional context
아래 RequestParameter를 위한 검증 어노테이션 작성
- PageSize
- PageNumber
- Match
- TargetStratgy

관리 편의를 위해 일부 값들을 상수로 분리
- 아이디, 비밀번호 정규식
- valid에 적용할 제한 값들
- parameter의 기본 값

Closes #142 
